### PR TITLE
Update jore4 ingress to use the latest networking.k8s.io/v1 API

### DIFF
--- a/clusters/base/jore4-services/jore4-ingress.yaml
+++ b/clusters/base/jore4-services/jore4-ingress.yaml
@@ -1,6 +1,6 @@
 # Describes the jore4 ingress
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jore4-ingress
@@ -16,10 +16,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: jore4-frontend
-              servicePort: 80
+              service:
+                name: jore4-frontend
+                port:
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: jore4-backend
-              servicePort: 8080
+              service:
+                name: jore4-backend
+                port:
+                  number: 8080

--- a/clusters/dev/jore4-ingress-patch.yaml
+++ b/clusters/dev/jore4-ingress-patch.yaml
@@ -1,6 +1,6 @@
 # Patches the jore4 ingress to tell where to find the certificate from and what is the hostname
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jore4-ingress
@@ -15,10 +15,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: jore4-frontend
-              servicePort: 80
+              service:
+                name: jore4-frontend
+                port:
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: jore4-backend
-              servicePort: 8080
+              service:
+                name: jore4-backend
+                port:
+                  number: 8080

--- a/clusters/prod/jore4-ingress-patch.yaml
+++ b/clusters/prod/jore4-ingress-patch.yaml
@@ -1,6 +1,6 @@
 # Patches the jore4 ingress to tell where to find the certificate from and what is the hostname
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jore4-ingress
@@ -15,10 +15,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: jore4-frontend
-              servicePort: 80
+              service:
+                name: jore4-frontend
+                port:
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: jore4-backend
-              servicePort: 8080
+              service:
+                name: jore4-backend
+                port:
+                  number: 8080

--- a/clusters/test/jore4-ingress-patch.yaml
+++ b/clusters/test/jore4-ingress-patch.yaml
@@ -1,6 +1,6 @@
 # Patches the jore4 ingress to tell where to find the certificate from and what is the hostname
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: jore4-ingress
@@ -15,10 +15,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: jore4-frontend
-              servicePort: 80
+              service:
+                name: jore4-frontend
+                port:
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: jore4-backend
-              servicePort: 8080
+              service:
+                name: jore4-backend
+                port:
+                  number: 8080


### PR DESCRIPTION
Needs first AKS to be updated, so basically depends on: https://github.com/HSLdevcom/jore4-deploy/pull/37

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/4)
<!-- Reviewable:end -->
