### PR TITLE
Fix: Deploy auth backend hasura authorization hook

### DIFF
--- a/clusters/dev/jore4-auth.yaml
+++ b/clusters/dev/jore4-auth.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-auth-image"
-          image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+          image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/dev/jore4-hasura.yaml
+++ b/clusters/dev/jore4-hasura.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-hasura-image"
-          image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+          image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/docker-compose/docker-compose.yml
+++ b/clusters/docker-compose/docker-compose.yml
@@ -5,7 +5,7 @@ version: "3.8"
 services:
   jore4-auth:
     container_name: "auth"
-    image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+    image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
     restart: "unless-stopped"
     networks:
       - jore4
@@ -38,7 +38,7 @@ services:
 
   jore4-hasura:
     container_name: "hasura"
-    image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+    image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
     restart: "unless-stopped"
     networks:
       - jore4

--- a/clusters/e2e/jore4-auth.yaml
+++ b/clusters/e2e/jore4-auth.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-auth-image"
-          image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+          image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/e2e/jore4-hasura.yaml
+++ b/clusters/e2e/jore4-hasura.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-hasura-image"
-          image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+          image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/playg/jore4-auth.yaml
+++ b/clusters/playg/jore4-auth.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-auth-image"
-          image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+          image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/playg/jore4-hasura.yaml
+++ b/clusters/playg/jore4-hasura.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-hasura-image"
-          image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+          image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/prod/jore4-auth.yaml
+++ b/clusters/prod/jore4-auth.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-auth-image"
-          image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+          image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/prod/jore4-hasura.yaml
+++ b/clusters/prod/jore4-hasura.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-hasura-image"
-          image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+          image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/test/jore4-auth.yaml
+++ b/clusters/test/jore4-auth.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-auth-image"
-          image: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+          image: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/clusters/test/jore4-hasura.yaml
+++ b/clusters/test/jore4-hasura.yaml
@@ -20,7 +20,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: "jore4-hasura-image"
-          image: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+          image: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
           imagePullPolicy: Always
           ports:
           - containerPort: 8080

--- a/generate/values/common.yaml
+++ b/generate/values/common.yaml
@@ -11,7 +11,7 @@ microServices:
   auth:
     serviceName: "auth"
     serviceType: "ClusterIP"
-    dockerImage: "hsldevcom/jore4-auth:auth-webhook-deployment--703a022cfd5f3ad3384f6c5715b3806bce275e88"
+    dockerImage: "hsldevcom/jore4-auth:main--60a1dd2715803e63cdde7f36e6955d5f0eb29d0a"
     ports:
       - containerPort: 8080
         localPort: 3200
@@ -39,7 +39,7 @@ microServices:
   hasura:
     serviceName: "hasura"
     serviceType: "ClusterIP"
-    dockerImage: "hsldevcom/jore4-hasura:auth-webhook-deployment--94205d9f3669545134cda6553e5dc820f2df825f"
+    dockerImage: "hsldevcom/jore4-hasura:main--3d8d576622696e67b7d9de470e1ed4aa2a50024f"
     ports:
       - containerPort: 8080
         localPort: 3201


### PR DESCRIPTION
Until now, the flux configuration was referring to PR-docker-builds of
hasura and auth backend, which were added as part of the hasura
authorization hook deployment in
1e585b00d0864936ccd56e2c7a8a1645054cbd89 .

This commit changes the references to use the main branch docker builds
of hasura and the auth backend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/34)
<!-- Reviewable:end -->
