### PR TITLE
Add versioning to docker-compose releases

### DIFF
--- a/.github/workflows/release-docker-compose.yml
+++ b/.github/workflows/release-docker-compose.yml
@@ -21,8 +21,11 @@ jobs:
           echo "Release version: ${RELEASE_VERSION}"
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
 
+          # create a version file (to enable tracking version changes)
+          echo "${GITHUB_SHA}" > RELEASE_VERSION.txt
+
           # create a tar.gz of the docker-compose config + dependencies
-          tar -czvf e2e-docker-compose.tar.gz -C clusters/docker-compose .
+          tar -czvf e2e-docker-compose.tar.gz RELEASE_VERSION.txt -C clusters/docker-compose .
 
           # delete and recreate github release
           gh release delete ${RELEASE_VERSION} || echo "There in no previous github release with the name '${RELEASE_VERSION}'"
@@ -30,4 +33,5 @@ jobs:
 
           # append the tar.gz package and also the individual files (just in case) to the release
           gh release upload ${RELEASE_VERSION} clusters/docker-compose/**
+          gh release upload ${RELEASE_VERSION} RELEASE_VERSION.txt
           gh release upload ${RELEASE_VERSION} e2e-docker-compose.tar.gz

--- a/README.md
+++ b/README.md
@@ -501,9 +501,20 @@ your custom docker-compose override yaml file).
 
 set -euo pipefail
 
-# download latest version of the docker-compose package
+# initialize package folder
 mkdir -p ./docker
-curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/e2e-docker-compose.tar.gz | tar -xvf - -C ./docker/
+
+# compare versions
+GITHUB_VERSION=$(curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/RELEASE_VERSION.txt --silent)
+LOCAL_VERSION=$(cat ./docker/RELEASE_VERSION.txt || echo "unknown")
+
+# download latest version of the docker-compose package in case it has changed
+if [ "$GITHUB_VERSION" != "$LOCAL_VERSION" ]; then
+  echo "E2E docker-compose package is not up to date, downloading a new version."
+  curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/e2e-docker-compose/e2e-docker-compose.tar.gz --silent | tar -xf - -C ./docker/
+else
+  echo "E2E docker-compose package is up to date, no need to download new version."
+fi
 
 # start up all services
 docker-compose -f ./docker/docker-compose.yml up


### PR DESCRIPTION
This allows the individual repositories to monitor for changes and only download the latest package in case it changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/37)
<!-- Reviewable:end -->
