### PR TITLE
Update Digiroad dataset to version 2022-02 within map-matching service

### DIFF
--- a/clusters/dev/jore4-mapmatchingdb.yaml
+++ b/clusters/dev/jore4-mapmatchingdb.yaml
@@ -84,7 +84,7 @@ metadata:
   name: "jore4-mapmatchingdb-env"
   namespace: hsl-jore4
 data:
-  DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+  DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"
   POSTGRES_DB: "jore4mapmatching"
   SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
 

--- a/clusters/docker-compose/docker-compose.yml
+++ b/clusters/docker-compose/docker-compose.yml
@@ -141,7 +141,7 @@ services:
     networks:
       - jore4
     environment:
-      DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+      DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"
       POSTGRES_DB: "jore4mapmatching"
       SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
     ports:

--- a/clusters/playg/jore4-mapmatchingdb.yaml
+++ b/clusters/playg/jore4-mapmatchingdb.yaml
@@ -84,7 +84,7 @@ metadata:
   name: "jore4-mapmatchingdb-env"
   namespace: hsl-jore4
 data:
-  DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+  DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"
   POSTGRES_DB: "jore4mapmatching"
   SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
 

--- a/clusters/prod/jore4-mapmatchingdb.yaml
+++ b/clusters/prod/jore4-mapmatchingdb.yaml
@@ -84,7 +84,7 @@ metadata:
   name: "jore4-mapmatchingdb-env"
   namespace: hsl-jore4
 data:
-  DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+  DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"
   POSTGRES_DB: "jore4mapmatching"
   SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
 

--- a/clusters/test/jore4-mapmatchingdb.yaml
+++ b/clusters/test/jore4-mapmatchingdb.yaml
@@ -84,7 +84,7 @@ metadata:
   name: "jore4-mapmatchingdb-env"
   namespace: hsl-jore4
 data:
-  DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+  DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"
   POSTGRES_DB: "jore4mapmatching"
   SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
 

--- a/generate/values/common.yaml
+++ b/generate/values/common.yaml
@@ -181,4 +181,4 @@ microServices:
     env:
       SECRET_STORE_BASE_PATH: "/mnt/secrets-store"
       POSTGRES_DB: jore4mapmatching
-      DIGIROAD_ROUTING_DUMP_VERSION: "2022-02-28"
+      DIGIROAD_ROUTING_DUMP_VERSION: "2022-03-11"


### PR DESCRIPTION
New municipalities are included: Askola (18), Lohja (444), Mäntsälä (505), Nurmijärvi (543), Pornainen (611), Porvoo (638), Vihti (927)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/136)
<!-- Reviewable:end -->
