### PR TITLE
Increase the amount of docker image tags checked from docker hub

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Find latest image with "main" tag from docker hub
         run: |
-          dockerHubTag="$(curl --silent --get -H \"Accept: application/json\" https://hub.docker.com/v2/repositories/hsldevcom/${{ matrix.docker-image }}/tags/\?page_size=25\&page=1\&ordering=last_updated | jq --raw-output 'first(.results[] | select(.name | startswith("${{ matrix.tag-prefix }}"))).name')"
+          dockerHubTag="$(curl --silent --get -H \"Accept: application/json\" https://hub.docker.com/v2/repositories/hsldevcom/${{ matrix.docker-image }}/tags/\?page_size=100\&page=1\&ordering=last_updated | jq --raw-output 'first(.results[] | select(.name | startswith("${{ matrix.tag-prefix }}"))).name')"
           echo $dockerHubTag
           dockerHubImage="hsldevcom/${{ matrix.docker-image }}:${dockerHubTag}"
           echo $dockerHubImage


### PR DESCRIPTION
The previous 25 was not enough as hasura is producing a huge amount of temporary docker images. Increased it to 100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/214)
<!-- Reviewable:end -->
