### PR TITLE
Add branch name to test docker bundles

### DIFF
--- a/.github/workflows/test-e2e-action.yml
+++ b/.github/workflows/test-e2e-action.yml
@@ -17,12 +17,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Retrieve branch name
+        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
+
       # note: make sure to only run a single workflow from this as you cannot create multiple
       # releases with the same name at once (e.g. only run workflow on 'pull_request')
       - name: Create docker compose bundle release for testing
         uses: ./github-actions/create-docker-bundle-release
         with:
-          release_name: e2e-setup-test-bundle
+          release_name: e2e-setup-test-bundle-${{ env.BRANCH_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       # To make sure the just created release is available for download, let's wait a bit...
@@ -62,10 +65,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Retrieve branch name
+        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
+
       - name: start e2e env
         uses: ./github-actions/setup-e2e-environment
         with:
-          bundle_version: e2e-setup-test-bundle
+          bundle_version: e2e-setup-test-bundle-${{ env.BRANCH_NAME }}
           ui_version: ${{ matrix.ui-docker-image }}
           hasura_version: ${{ matrix.hasura-docker-image }}
           auth_version: ${{ matrix.auth-docker-image }}


### PR DESCRIPTION
As multiple PRs try to use the same release name, they tend to conflict. Adding the branch name to the bundle release name should help with this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hsldevcom/jore4-flux/224)
<!-- Reviewable:end -->
