### PR TITLE
Remove test release creation from e2e action tests

### DIFF
--- a/.github/workflows/test-e2e-action.yml
+++ b/.github/workflows/test-e2e-action.yml
@@ -10,42 +10,7 @@ on:
     branches: ["**"]
 
 jobs:
-  create-test-bundle:
-    runs-on: ubuntu-20.04
-
-    outputs:
-      release_name: ${{ steps.set_release_name.outputs.release_name }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Retrieve branch name
-        uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
-
-      - name: Set release name as output
-        id: set_release_name
-        run: |
-          # making sure that the release name is unique
-          RELEASE_NAME="e2e-setup-test-bundle-${{ env.BRANCH_NAME }}-$(date +%s)"
-          echo "RELEASE_NAME=${RELEASE_NAME}" >> "${GITHUB_ENV}"
-          echo "::set-output name=release_name::${RELEASE_NAME}"
-
-      # note: make sure to only run a single workflow from this as you cannot create multiple
-      # releases with the same name at once (e.g. only run workflow on 'pull_request')
-      - name: Create docker compose bundle release for testing
-        uses: ./github-actions/create-docker-bundle-release
-        with:
-          release_name: ${{ env.RELEASE_NAME }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      # To make sure the just created release is available for download, let's wait a bit...
-      - name: Aaaand wait...
-        run: |
-          sleep 15
-
   test-e2e-setup-action:
-    needs: create-test-bundle
     runs-on: ubuntu-20.04
 
     strategy:
@@ -92,6 +57,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      # making the directory structure compatible with the github release dir structure to be able to run the tests
+      - name: Move the docker bundle's folder
+        run: |
+          mv ./clusters/docker-compose ./docker
+
       - name: Retrieve branch name
         uses: HSLdevcom/jore4-tools/github-actions/extract-metadata@extract-metadata-v1
 
@@ -105,7 +75,7 @@ jobs:
       - name: start e2e env
         uses: ./github-actions/setup-e2e-environment
         with:
-          bundle_version: ${{needs.create-test-bundle.outputs.release_name}}
+          bundle_version: "" # use the local setup instead of referencing a bundle
           ui_version: ${{ matrix.ui-docker-image }}
           hasura_version: ${{ matrix.hasura-docker-image }}
           auth_version: ${{ matrix.auth-docker-image }}

--- a/github-actions/setup-e2e-environment/action.yml
+++ b/github-actions/setup-e2e-environment/action.yml
@@ -54,6 +54,8 @@ runs:
   using: "composite"
   steps:
     - name: Download and extract e2e docker-compose release
+      # if bundle_version is defined, download it from releases. Otherwise just use the local setup as-is.
+      if: "${{ inputs.bundle_version != '' }}"
       run: |
         mkdir -p ${{ github.workspace }}/docker
         curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/${{ inputs.bundle_version }}/e2e-docker-compose.tar.gz --silent -o compose-bundle.tar.gz


### PR DESCRIPTION
It caused github API rate errors often and is not actually that important part of the test

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-flux/511)
<!-- Reviewable:end -->
