### PR TITLE
Remove uncompiled files from release bundle

### DIFF
--- a/github-actions/create-docker-bundle-release/action.yml
+++ b/github-actions/create-docker-bundle-release/action.yml
@@ -30,7 +30,6 @@ runs:
         gh release create ${RELEASE_VERSION} --notes "docker-compose config with nginx.conf and secrets"
 
         # append the tar.gz package and also the individual files (just in case) to the release
-        gh release upload ${RELEASE_VERSION} clusters/docker-compose/**
         gh release upload ${RELEASE_VERSION} RELEASE_VERSION.txt
         gh release upload ${RELEASE_VERSION} e2e-docker-compose.tar.gz
       shell: bash


### PR DESCRIPTION
Only the tar.gz file is used anywhere anyway. Hopefully this helps to avoid the API rate limit issues...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-flux/512)
<!-- Reviewable:end -->
