### PR TITLE
Remove the bundle tar.gz file in setup-e2e action

### DIFF
--- a/github-actions/setup-e2e-environment/action.yml
+++ b/github-actions/setup-e2e-environment/action.yml
@@ -57,13 +57,8 @@ runs:
       run: |
         mkdir -p ${{ github.workspace }}/docker
         curl -L https://github.com/HSLdevcom/jore4-flux/releases/download/${{ inputs.bundle_version }}/e2e-docker-compose.tar.gz --silent -o compose-bundle.tar.gz
-        tar -xzf compose-bundle.tar.gz -C ./docker/ | bash
-      shell: bash
-
-    - name: Debug on failure
-      if: ${{ failure() }}
-      run: |
-        cat compose-bundle.tar.gz
+        tar -xzf compose-bundle.tar.gz -C ${{ github.workspace }}/docker/ | bash
+        rm compose-bundle.tar.gz
       shell: bash
 
     - name: Start e2e environment


### PR DESCRIPTION
The handing file causes git status issues in some CI jobs (the git workspace is not clean)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/HSLdevcom/jore4-flux/517)
<!-- Reviewable:end -->
